### PR TITLE
fix: error while compiling y.tab.c file

### DIFF
--- a/Part 2 - Adding the Grammar Rules/parser1.y
+++ b/Part 2 - Adding the Grammar Rules/parser1.y
@@ -3,7 +3,8 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
+
+    char * yytext;
     
     void yyerror(const char *s);
     int yylex();

--- a/Part 3 - Generating the Symbol Table/parser2.y
+++ b/Part 3 - Generating the Symbol Table/parser2.y
@@ -3,16 +3,7 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
     
-    void yyerror(const char *s);
-    int yylex();
-    int yywrap();
-    void add(char);
-    void insert_type();
-    int search(char *);
-    void insert_type();
-
     struct dataType {
         char * id_name;
         char * data_type;
@@ -24,6 +15,15 @@
     int q;
     char type[10];
     extern int countn;
+	char * yytext;
+
+    void yyerror(const char *s);
+    int yylex();
+    int yywrap();
+    void add(char);
+    void insert_type();
+    int search(char *);
+    void insert_type();
 %}
 
 %token VOID CHARACTER PRINTFF SCANFF INT FLOAT CHAR FOR IF ELSE TRUE FALSE NUMBER FLOAT_NUM ID LE GE EQ NE GT LT AND OR STR ADD MULTIPLY DIVIDE SUBTRACT UNARY INCLUDE RETURN 

--- a/Part 4 - Creating the Syntax Tree/parser3.y
+++ b/Part 4 - Creating the Syntax Tree/parser3.y
@@ -3,18 +3,7 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
-    void yyerror(const char *s);
-    int yylex();
-    int yywrap();
-    void add(char);
-    void insert_type();
-    int search(char *);
-    void insert_type();
-    void printtree(struct node*);
-    void printInorder(struct node *);
-    struct node* mknode(struct node *left, struct node *right, char *token);
-
+	
     struct dataType {
         char * id_name;
         char * data_type;
@@ -31,6 +20,18 @@
 	struct node *right; 
 	char *token; 
     };
+	char *yytext;
+
+    void yyerror(const char *s);
+    int yylex();
+    int yywrap();
+    void add(char);
+    void insert_type();
+    int search(char *);
+    void insert_type();
+    void printtree(struct node*);
+    void printInorder(struct node *);
+    struct node* mknode(struct node *left, struct node *right, char *token);
 %}
 
 %union { 

--- a/Part 5 - Adding the Semantic Analyzer/parser4.y
+++ b/Part 5 - Adding the Semantic Analyzer/parser4.y
@@ -3,22 +3,7 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
-    void yyerror(const char *s);
-    int yylex();
-    int yywrap();
-    void add(char);
-    void insert_type();
-    int search(char *);
-	void insert_type();
-	void print_tree(struct node*);
-	void print_inorder(struct node *);
-    void check_declaration(char *);
-	void check_return_type(char *);
-	int check_types(char *, char *);
-	char *get_type(char *);
-	struct node* mknode(struct node *left, struct node *right, char *token);
-
+	
     struct dataType {
         char * id_name;
         char * data_type;
@@ -36,13 +21,27 @@
 	char buff[100];
 	char errors[10][100];
 	char reserved[10][10] = {"int", "float", "char", "void", "if", "else", "for", "main", "return", "include"};
-
 	struct node { 
 		struct node *left; 
 		struct node *right; 
 		char *token; 
 	};
+	char *yytext;
 
+    void yyerror(const char *s);
+    int yylex();
+    int yywrap();
+    void add(char);
+    void insert_type();
+    int search(char *);
+	void insert_type();
+	void print_tree(struct node*);
+	void print_inorder(struct node *);
+    void check_declaration(char *);
+	void check_return_type(char *);
+	int check_types(char *, char *);
+	char *get_type(char *);
+	struct node* mknode(struct node *left, struct node *right, char *token);
 %}
 
 %union { struct var_name { 

--- a/Part 6 - Intermediate Code Generation/parser5.y
+++ b/Part 6 - Intermediate Code Generation/parser5.y
@@ -3,22 +3,7 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
-    void yyerror(const char *s);
-    int yylex();
-    int yywrap();
-    void add(char);
-    void insert_type();
-    int search(char *);
-	void insert_type();
-	void print_tree(struct node*);
-	void print_inorder(struct node *);
-    void check_declaration(char *);
-	void check_return_type(char *);
-	int check_types(char *, char *);
-	char *get_type(char *);
-	struct node* mknode(struct node *left, struct node *right, char *token);
-
+	
     struct dataType {
         char * id_name;
         char * data_type;
@@ -40,6 +25,7 @@
 	char errors[10][100];
 	char reserved[10][10] = {"int", "float", "char", "void", "if", "else", "for", "main", "return", "include"};
 	char icg[50][100];
+	char *yytext;
 
 	struct node { 
 		struct node *left; 
@@ -47,6 +33,20 @@
 		char *token; 
 	};
 
+    void yyerror(const char *s);
+    int yylex();
+    int yywrap();
+    void add(char);
+    void insert_type();
+    int search(char *);
+	void insert_type();
+	void print_tree(struct node*);
+	void print_inorder(struct node *);
+    void check_declaration(char *);
+	void check_return_type(char *);
+	int check_types(char *, char *);
+	char *get_type(char *);
+	struct node* mknode(struct node *left, struct node *right, char *token);
 %}
 
 %union { struct var_name { 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Frontend Phase of a C Compiler
 
+## Environment
+* flex 2.6.4
+* bison (GNU Bison) 3.5.1
+* Ubuntu 20.04.5 LTS
+
 ## Using the Compiler
 
 ```
 lex lexer.l
-yacc -d -v parser.y
-gcc -ll -w y.tab.c
+yacc -d parser.y
+cc lex.yy.c y.tab.c
 ./a.out<input1.c
 ```
 

--- a/parser.y
+++ b/parser.y
@@ -3,22 +3,6 @@
     #include<string.h>
     #include<stdlib.h>
     #include<ctype.h>
-    #include"lex.yy.c"
-    void yyerror(const char *s);
-    int yylex();
-    int yywrap();
-    void add(char);
-    void insert_type();
-    int search(char *);
-	void insert_type();
-	void print_tree(struct node*);
-	void print_tree_util(struct node*, int);
-	void print_inorder(struct node *);
-    void check_declaration(char *);
-	void check_return_type(char *);
-	int check_types(char *, char *);
-	char *get_type(char *);
-	struct node* mknode(struct node *left, struct node *right, char *token);
 
     struct dataType {
         char * id_name;
@@ -27,11 +11,12 @@
         int line_no;
 	} symbol_table[40];
 
+	char * yytext;
+	struct node *head;
     int count=0;
     int q;
 	char type[10];
     extern int countn;
-	struct node *head;
 	int sem_errors=0;
 	int ic_idx=0;
 	int temp_var=0;
@@ -47,7 +32,22 @@
 		struct node *right; 
 		char *token; 
 	};
-
+	
+    void yyerror(const char *s);
+    int yylex();
+    int yywrap();
+    void add(char);
+    void insert_type();
+    int search(char *);
+	void insert_type();
+	void print_tree(struct node* tree);
+	void print_tree_util(struct node *root, int space);
+	void print_inorder(struct node *tree);
+    void check_declaration(char *);
+	void check_return_type(char *);
+	int check_types(char *, char *);
+	char *get_type(char *);
+	struct node* mknode(struct node *left, struct node *right, char *token);
 %}
 
 %union { struct var_name { 


### PR DESCRIPTION
This change resolves #1 and issues of missing or conflict declarations by following steps:
1. removing the `#include"lex.yy.c"` from yacc file. (For Part 2-6)
2. adding declarations of `char * yytext;` before using in yacc file. (For Part 2-6)
3. Adjust the order of declarations of variables and functions. (For Part 3-6)

Also, updated README.md by adding the information of environment which is used.

Thanks for your explanation for each step.